### PR TITLE
Update mobileAuthenticate validation and parameters

### DIFF
--- a/src/Authentication/Exception/ValidationException.php
+++ b/src/Authentication/Exception/ValidationException.php
@@ -4,6 +4,11 @@ namespace BitWeb\IdServices\Authentication\Exception;
 
 class ValidationException extends AuthenticationException
 {
+    public static function missingPersonalCodeAndPhoneNumber()
+    {
+        return new static('Please enter personal code or phone number.');
+    }
+
     public static function invalidPersonalCode($personalCode, $chars = 11)
     {
         return new static(


### PR DESCRIPTION
- Fixed mobileAuhtenticate validation. According to DigiDocService spec $personalCode or $phoneNumber must be present not both.
  https://www.sk.ee/upload/files/DigiDocService_spec_eng.pdf
- Add $returnCertData and $returnRevocationData params to mobileAuthenticate.
